### PR TITLE
Fixed connection test error

### DIFF
--- a/.harness/Pipeline.yaml
+++ b/.harness/Pipeline.yaml
@@ -91,4 +91,4 @@
                     shell: Sh
                     command: |-
                       sleep 10
-                      curl localhost:5000
+                      curl python_server:5000


### PR DESCRIPTION
command: |-
                      sleep 10
                      curl localhost:5000 
                      will return
                      curl: (7) Failed to connect to [localhost](https://app.harness.io/ng/localhost) port 8080: Connection refused
                      
curl python_server:5000 (python_server: background-step id) fixes the issue